### PR TITLE
Try to make the local IP smarter

### DIFF
--- a/n2n_v2/edge.8
+++ b/n2n_v2/edge.8
@@ -67,7 +67,10 @@ can be specified by two invocations of -l <addr>:<port>. eg.
 \-L <local_ip>
 adds a local ip address which is sent to other nodes on registration. The nodes
 will then try to register both with the address seen by the supernode and the
-local address. This can be used to circumvent the behind-same-nat problem.
+local address. This can be used to circumvent the behind-same-nat problem.  The
+local_ip value can either be an IP address, or the value "auto" which will try
+to guess a valid local ip automatically.  The local ip can also be changed via
+the management interface.
 .TP
 \-p <num>
 binds edge to the given UDP port. Useful for keeping the same external socket

--- a/n2n_v2/edge.c
+++ b/n2n_v2/edge.c
@@ -2409,7 +2409,7 @@ int real_main(int argc, char* argv[])
             strncpy( eee.local_ip_str, optarg, N2N_EDGE_LOCAL_IP_SIZE);
             if ( N2N_EDGE_LOCAL_IP_SIZE > 0 )
                 eee.local_ip_str[N2N_EDGE_LOCAL_IP_SIZE - 1] = '\0';
-            traceEvent(TRACE_DEBUG, "Storing local_ip_str = %s\n", (eee.sn_ip_array[eee.sn_num]) );
+            traceEvent(TRACE_DEBUG, "Storing local_ip_str = %s\n", (eee.local_ip_str) );
             break;
         }
 

--- a/n2n_v2/edge.c
+++ b/n2n_v2/edge.c
@@ -1618,9 +1618,9 @@ static void readFromMgmtSocket( n2n_edge_t * eee, int * keep_running )
 				c++;
 				msg_len = 0;
 				msg_len += snprintf( (char *)(udp_buf+msg_len), (N2N_PKT_BUF_SIZE-msg_len),
-					">  %i: %s -> %s last: %li\n", c, macaddr_str( mac_buf, lpi->mac_addr ), 
+                                        ">  %i: %s -> %s last: %li(%ld sec ago)\n", c, macaddr_str( mac_buf, lpi->mac_addr ),
 						sock_to_cstr( sockbuf, &(lpi->sock) ),
-						lpi->last_seen);
+                                                lpi->last_seen, (now - lpi->last_seen));
 				sendto( eee->udp_mgmt_sock, udp_buf, msg_len, 0,
 					(struct sockaddr *)&sender_sock, sizeof(struct sockaddr_in) );
 			}
@@ -1638,14 +1638,14 @@ static void readFromMgmtSocket( n2n_edge_t * eee, int * keep_running )
 				msg_len = 0;
                 if(lpi->num_sockets == 0)
                     msg_len += snprintf( (char *)(udp_buf+msg_len), (N2N_PKT_BUF_SIZE-msg_len),
-                        ">  %i: %s -> (no info) last: %li\n", c,
+                        ">  %i: %s -> (no info) last: %li(%ld sec ago)\n", c,
                         macaddr_str( mac_buf, lpi->mac_addr ), 
-                        lpi->last_seen);
+                        lpi->last_seen, (now - lpi->last_seen));
                 else
                     msg_len += snprintf( (char *)(udp_buf+msg_len), (N2N_PKT_BUF_SIZE-msg_len),
-                        ">  %i: %s -> %s last: %li\n", c, macaddr_str( mac_buf, lpi->mac_addr ), 
+                        ">  %i: %s -> %s last: %li(%ld sec ago)\n", c, macaddr_str( mac_buf, lpi->mac_addr ),
                             sock_to_cstr( sockbuf, lpi->sockets ),
-                            lpi->last_seen);
+                            lpi->last_seen, (now - lpi->last_seen));
                 if(lpi->num_sockets > 1)
                     msg_len += snprintf( (char *)(udp_buf+msg_len), (N2N_PKT_BUF_SIZE-msg_len),
                         "                           %s\n",

--- a/n2n_v2/edge.c
+++ b/n2n_v2/edge.c
@@ -2168,6 +2168,7 @@ static int scan_address( char * ip_addr, size_t addr_size,
 }
 
 static int run_loop(n2n_edge_t * eee );
+int real_main(int argc, char* argv[]);
 
 #define N2N_NETMASK_STR_SIZE    16 /* dotted decimal 12 numbers + 3 dots */
 #define N2N_MACNAMSIZ           18 /* AA:BB:CC:DD:EE:FF + NULL*/

--- a/n2n_v2/edge.c
+++ b/n2n_v2/edge.c
@@ -542,7 +542,8 @@ static void help() {
   printf("-K <key file>            | Specify a key schedule file to load. Not with -k.\n");
   printf("-s <netmask>             | Edge interface netmask in dotted decimal notation (255.255.255.0).\n");
   printf("-l <supernode host:port> | Supernode IP:port\n");
-  printf("-i <local_ip>            | Add local ip to bypass between same nat problem\n");
+  printf("-L <local_ip>            | Add local ip to bypass between same nat problem\n");
+  printf("-i <interval>            | Set the NAT hole-punch interval (default 20seconds)\n");
   printf("-b                       | Periodically resolve supernode IP\n");
   printf("                         : (when supernodes are running on dynamic IPs)\n");
   printf("-p <local port>          | Fixed local UDP port.\n");


### PR DESCRIPTION
Add a feature to allow the local IP to be automatically guessed (currently, simply from the address the kernel selects to talk to the supernode - which is assumed to be our upstream-facing internal address.  On most simple end-user systems, this is always going to be right).  Also allow the local IP value to be get/set via the management interface, so a DHCP hook script could be written to set or recalculate the local IP when the address changes.
