### PR TITLE
fix openssl build error on macOS

### DIFF
--- a/n2n_v2/CMakeLists.txt
+++ b/n2n_v2/CMakeLists.txt
@@ -35,6 +35,12 @@ endif(NOT DEFINED CMAKE_BUILD_TYPE)
 #(thanks to Robert Gibbon) 
 #PLATOPTS_SPARC64=-mcpu=ultrasparc -pipe -fomit-frame-pointer -ffast-math -finline-functions -fweb -frename-registers -mapp-regs
 
+#for macOS, find openssl installed by Homebrew
+# cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl ..
+if(APPLE)
+find_package(openssl REQUIRED)
+endif(APPLE)
+
 # None
 if(NOT WIN32)
 set(CMAKE_C_FLAGS "-Wall -Wshadow -Wpointer-arith -Wmissing-declarations -Wnested-externs -fPIC")
@@ -46,6 +52,12 @@ set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG")
 set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
 endif(NOT WIN32)
+
+#for macOS, add openssl include dir
+if(APPLE)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I${OPENSSL_INCLUDE_DIR}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${OPENSSL_INCLUDE_DIR}")
+endif(APPLE)
 
 ## DEBUG FOR CMAKE
 #message(${N2N_VERSION}) 


### PR DESCRIPTION
Tested on macOS 10.12.5 with Xcode 8.3.3 and openssl 1.0.2l installed by Homebrew.

## Before:

    ~/n2n/n2n_v2/transform_aes.c:12:10: fatal error:
          'openssl/aes.h' file not found
    #include "openssl/aes.h"
             ^
    1 error generated.
    make[2]: *** [CMakeFiles/n2n.dir/transform_aes.c.o] Error 1
    make[1]: *** [CMakeFiles/n2n.dir/all] Error 2
    make: *** [all] Error 2

## After 

#### cmake

    cd n2n_v2
    mkdir build
    cd build
    cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl ..
    -- The C compiler identification is AppleClang 8.1.0.8020042
    -- The CXX compiler identification is AppleClang 8.1.0.8020042
    -- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc
    -- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -- works
    -- Detecting C compiler ABI info
    -- Detecting C compiler ABI info - done
    -- Detecting C compile features
    -- Detecting C compile features - done
    -- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++
    -- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -- works
    -- Detecting CXX compiler ABI info
    -- Detecting CXX compiler ABI info - done
    -- Detecting CXX compile features
    -- Detecting CXX compile features - done
    -- Found OpenSSL: /usr/local/opt/openssl/lib/libcrypto.dylib (found version "1.0.2l")
    -- Configuring done
    -- Generating done
    -- Build files have been written to: ~/n2n/n2n_v2/build

#### make

    [ 65%] Built target n2n
    [ 68%] Building C object CMakeFiles/benchmark.dir/benchmark.c.o
    [ 72%] Linking C executable benchmark
    [ 72%] Built target benchmark
    [ 75%] Building C object CMakeFiles/test.dir/test.c.o
    [ 79%] Linking C executable test
    [ 79%] Built target test
    [ 82%] Building C object CMakeFiles/supernode.dir/sn.c.o
    [ 86%] Linking C executable supernode
    [ 86%] Built target supernode
    [ 89%] Building C object CMakeFiles/edge.dir/edge.c.o
    [ 93%] Linking C executable edge
    [ 93%] Built target edge
    [ 96%] Building C object CMakeFiles/benchmark_hashtable.dir/benchmark_hashtable.c.o
    [100%] Linking C executable benchmark_hashtable
    [100%] Built target benchmark_hashtable

## Build

Install openssl libaray:

    brew install openssl

Generate makefiles:

    ~/n2n$ mkdir build
    ~/n2n$ cd build
    ~/n2n/build$ cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl ../

Generate Xcode project:

    ~/n2n$ mkdir build
    ~/n2n$ cd build
    ~/n2n/build$ cmake -G "Xcode" -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl ../