### PR TITLE
BUG FIX：If there are too many edge clients to get the same hash code, the supernode can't process them correct

### DIFF
--- a/n2n_v2/n2n.h
+++ b/n2n_v2/n2n.h
@@ -207,7 +207,7 @@ typedef struct peer_info peer_info_t;
 })
 */
 
-#define PEER_INFO_COMPARATOR(e1, e2) (strncmp((const char*)(e1)->mac_addr, (const char*)(e2)->mac_addr, sizeof(n2n_mac_t)))
+#define PEER_INFO_COMPARATOR(e1, e2) (memcmp(e1->mac_addr, e2->mac_addr, sizeof(n2n_mac_t)))
 
 unsigned int peer_info_t_hash_function(peer_info_t *e);
 


### PR DESCRIPTION
strncmp will always return 0 when the virtual mac is start with 0x00，which cause the hash list can not return right edge client info